### PR TITLE
require normalize before all other CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ And then execute:
 
 And then in your application.css
 
-    *= require_self
     *= require normalize-rails
+    *= require_self
     *= require_tree .
     
 Add it before require_tree so that you can override any of its styles.


### PR DESCRIPTION
if there is any CSS in application.css, or if application.css is instead application.css.scss and it has `@include`s, then without this change, normalize will end up not being first.