### PR TITLE
gem version matches normalize css version

### DIFF
--- a/lib/normalize-rails/version.rb
+++ b/lib/normalize-rails/version.rb
@@ -1,5 +1,5 @@
 module Normalize
   module Rails
-    VERSION = "5.0.0"
+    VERSION = "6.0.0"
   end
 end


### PR DESCRIPTION
Syncing the normalize-rails version to match the normalize css version (6.0.0).